### PR TITLE
ci: publish to marketplace after tag-it creates a new tag

### DIFF
--- a/.github/workflows/tag-it.yml
+++ b/.github/workflows/tag-it.yml
@@ -30,9 +30,11 @@ jobs:
           node-version: '20'
       - name: Publish to VS Code Marketplace
         if: steps.tag-it.outputs.new-tag != ''
+        env:
+          VSCE_PAT: ${{ secrets.AZURE_PAT }}
         run: |
           npm install -g yarn
           yarn global add @vscode/vsce
           yarn
           vsce package
-          VSCE_PAT=${{ secrets.AZURE_PAT }} vsce publish
+          vsce publish

--- a/.github/workflows/tag-it.yml
+++ b/.github/workflows/tag-it.yml
@@ -18,7 +18,21 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wozniakpl/tag-it@v1
+        id: tag-it
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           create-release: 'true'
           pre-release-command: 'npm version $NEW_VERSION --no-git-tag-version'
+      - name: Set up Node.js
+        if: steps.tag-it.outputs.new-tag != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Publish to VS Code Marketplace
+        if: steps.tag-it.outputs.new-tag != ''
+        run: |
+          npm install -g yarn
+          yarn global add @vscode/vsce
+          yarn
+          vsce package
+          VSCE_PAT=${{ secrets.AZURE_PAT }} vsce publish


### PR DESCRIPTION
## Summary

- Extends `tag-it.yml` to publish to the VS Code Marketplace in the same job, right after a new tag is created
- Gated on `steps.tag-it.outputs.new-tag != ''` so publish steps only run on push-to-main events that actually produce a new tag (not on PR validation runs or no-bump pushes)
- Fixes the `GITHUB_TOKEN` limitation: tags created by Actions don't trigger other workflows, so `publish.yml` would never fire from an automated tag

## Flow after merge

```
merge to main → tag-it bumps package.json + creates vX.Y.Z tag → publish steps run → marketplace release
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)