### PR TITLE
refactor: extract vsce publish steps into a composite action

### DIFF
--- a/.github/actions/vsce-publish/action.yml
+++ b/.github/actions/vsce-publish/action.yml
@@ -1,0 +1,23 @@
+name: Publish to VS Code Marketplace
+description: Package and publish the VS Code extension using vsce
+
+inputs:
+  azure-pat:
+    description: Azure PAT for vsce authentication
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - shell: bash
+      env:
+        VSCE_PAT: ${{ inputs.azure-pat }}
+      run: |
+        npm install -g yarn
+        yarn global add @vscode/vsce
+        yarn
+        vsce package
+        vsce publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,20 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/vsce-publish
         with:
-          node-version: '20'
-      - name: Install yarn
-        run: npm install -g yarn
-      - name: Install vsce
-        run: yarn global add @vscode/vsce
-      - name: Install dependencies
-        run: yarn
-      - name: Package
-        run: vsce package
-      - name: Publish
-        run: |
-          VSCE_PAT=${{ secrets.AZURE_PAT }} vsce publish
+          azure-pat: ${{ secrets.AZURE_PAT }}

--- a/.github/workflows/tag-it.yml
+++ b/.github/workflows/tag-it.yml
@@ -23,18 +23,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           create-release: 'true'
           pre-release-command: 'npm version $NEW_VERSION --no-git-tag-version'
-      - name: Set up Node.js
-        if: steps.tag-it.outputs.new-tag != ''
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
       - name: Publish to VS Code Marketplace
         if: steps.tag-it.outputs.new-tag != ''
-        env:
-          VSCE_PAT: ${{ secrets.AZURE_PAT }}
-        run: |
-          npm install -g yarn
-          yarn global add @vscode/vsce
-          yarn
-          vsce package
-          vsce publish
+        uses: ./.github/actions/vsce-publish
+        with:
+          azure-pat: ${{ secrets.AZURE_PAT }}


### PR DESCRIPTION
## Summary

- Adds `.github/actions/vsce-publish/action.yml` — composite action that handles `setup-node`, yarn install, `vsce package`, and `vsce publish`
- `tag-it.yml` and `publish.yml` both call it via `uses: ./.github/actions/vsce-publish`
- Removes the duplicated 6-step publish sequence from both workflows
- Also fixes the lingering secret-in-run-block warning in `publish.yml` (was still using `VSCE_PAT=${{ secrets.AZURE_PAT }} vsce publish`)

## Structure after merge

```
.github/
  actions/
    vsce-publish/
      action.yml       ← single source of truth for publish logic
  workflows/
    tag-it.yml         ← calls composite action when new tag created
    publish.yml        ← calls composite action on v* tag push
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)