### PR TITLE
fix: bump engines.vscode to match @types/vscode ^1.101.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/wozniakpl/obfuscator",
   "publisher": "BartoszWozniakSolutions",
   "engines": {
-    "vscode": "^1.83.0"
+    "vscode": "^1.101.0"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
## Summary

- Bumps `engines.vscode` from `^1.83.0` to `^1.101.0` to match the installed `@types/vscode` version
- vsce rejects publishing when `@types/vscode` is newer than `engines.vscode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)