### PR TITLE
refactor: split publish into a separate job for independent reruns

### DIFF
--- a/.github/workflows/tag-it.yml
+++ b/.github/workflows/tag-it.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   tag-it:
     runs-on: ubuntu-latest
+    outputs:
+      new-tag: ${{ steps.tag-it.outputs.new-tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,8 +25,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           create-release: 'true'
           pre-release-command: 'npm version $NEW_VERSION --no-git-tag-version'
-      - name: Publish to VS Code Marketplace
-        if: steps.tag-it.outputs.new-tag != ''
-        uses: ./.github/actions/vsce-publish
+
+  publish:
+    needs: tag-it
+    if: needs.tag-it.outputs.new-tag != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/vsce-publish
         with:
           azure-pat: ${{ secrets.AZURE_PAT }}


### PR DESCRIPTION
## Summary

- Splits `tag-it.yml` from one job into two: `tag-it` and `publish`
- `tag-it` job exposes `new-tag` as a job output
- `publish` job runs only when `new-tag != ''`, using `needs: tag-it` and an `if` condition
- If publishing fails (e.g. expired PAT), you can re-run just the `publish` job from the Actions UI without re-triggering tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)